### PR TITLE
Bug fix: `ibuffer-projectile-root' did not return nil when the file was not in a project.

### DIFF
--- a/ibuffer-projectile.el
+++ b/ibuffer-projectile.el
@@ -85,8 +85,7 @@ If the file is not in a project, then nil is returned instead."
     (let ((file-name (buffer-file-name)))
       (when (and file-name
                  (ibuffer-projectile--include-file-p file-name))
-        (let ((projectile-require-project-root nil))
-          (projectile-project-root))))))
+        (ignore-errors (projectile-project-root))))))
 
 (define-ibuffer-filter projectile-root
     "Toggle current view to buffers with projectile root dir QUALIFIER."

--- a/ibuffer-projectile.el
+++ b/ibuffer-projectile.el
@@ -98,10 +98,16 @@ If the file is not in a project, then nil is returned instead."
 (defun ibuffer-projectile-generate-filter-groups ()
   "Create a set of ibuffer filter groups based on the projectile root dirs of buffers."
   (let ((roots (ibuffer-remove-duplicates
-                (delq nil (mapcar 'ibuffer-projectile-root (buffer-list))))))
+                (delq nil (mapcar (lambda (buf)
+                                    (let ((root (ibuffer-projectile-root buf)))
+                                      (when root
+                                        (cons (with-current-buffer buf
+                                                (projectile-project-name))
+                                              root))))
+                                  (buffer-list))))))
     (mapcar (lambda (root)
-              (cons (abbreviate-file-name root)
-                    `((projectile-root . ,root))))
+              (cons (format "Projectile:%s" (car root))
+                    `((projectile-root . ,(cdr root)))))
             roots)))
 
 ;;;###autoload

--- a/ibuffer-projectile.el
+++ b/ibuffer-projectile.el
@@ -82,8 +82,9 @@ This option can be used to exclude certain files from the grouping mechanism."
   "Return root-dir for BUF.
 If the file is not in a project, then nil is returned instead."
   (with-current-buffer buf
-    (let ((file-name (or buffer-file-name default-directory)))
-      (when (ibuffer-projectile--include-file-p file-name)
+    (let ((file-name (buffer-file-name)))
+      (when (and file-name
+                 (ibuffer-projectile--include-file-p file-name))
         (let ((projectile-require-project-root nil))
           (projectile-project-root))))))
 


### PR DESCRIPTION
It returned `default-directory' instead which result in ibuffer pollution with an non existing project [~/].