### PR TITLE
Group dired buffers as well

### DIFF
--- a/ibuffer-projectile.el
+++ b/ibuffer-projectile.el
@@ -87,7 +87,7 @@ This option can be used to exclude certain files from the grouping mechanism."
   "Return a cons cell (project-name . root-dir) for BUF.
 If the file is not in a project, then nil is returned instead."
   (with-current-buffer buf
-    (let ((file-name (buffer-file-name))
+    (let ((file-name (ibuffer-buffer-file-name))
           (root (ignore-errors (projectile-project-root))))
       (when (and file-name
                  root


### PR DESCRIPTION
Dired buffers are not currently included in the project they belong to
but they are collected and listed under the "Default".  This commit
changes this behaviour so that you can find related dired buffers
under the projects as well.

This closes #6.