### PR TITLE
add filter-groups-extra for the default list

### DIFF
--- a/ibuffer-projectile.el
+++ b/ibuffer-projectile.el
@@ -97,6 +97,11 @@ name, and the root directory path."
   :type 'function
   :group 'ibuffer-projectile)
 
+(defcustom ibuffer-projectile-filter-groups-extra '()
+  "A static list of filter groups to apply to all non-projectile buffers."
+  ;:type 'list
+  :group 'ibuffer-projectile)
+
 (defun ibuffer-projectile-default-group-name (project-name root-dir)
   "Produce an ibuffer group name string for PROJECT-NAME and ROOT-DIR."
   (format "%s%s" ibuffer-projectile-prefix project-name))
@@ -160,10 +165,11 @@ If the file is not in a project, then nil is returned instead."
   "Create a set of ibuffer filter groups based on the projectile root dirs of buffers."
   (let ((roots (seq-uniq
                 (delq nil (mapcar 'ibuffer-projectile-root (buffer-list))))))
-    (mapcar (lambda (root)
+    (append (mapcar (lambda (root)
               (cons (funcall ibuffer-projectile-group-name-function (car root) (cdr root))
                     `((projectile-root . ,root))))
-            roots)))
+            roots)
+            ibuffer-projectile-filter-groups-extra)))
 
 ;;;###autoload
 (defun ibuffer-projectile-set-filter-groups ()


### PR DESCRIPTION
This allows users to add their own filter groups to the `Default` group. With the following doomemacs config, I am able to produce the following ibuffer display:

<img width="543" height="284" alt="2025-08-07_10-34" src="https://github.com/user-attachments/assets/0b0871f8-14cc-4825-8a78-0638f65d69e1" />

I think this resolves the expected UX of #15 by allowing users to further customize the default filters, but it doesn't address the top-level issue of overriding `ibuffer-filter-groups`. Depending on how you feel about this fix I think this can close #15.
 
```
;; config.el
(use-package! ibuffer-projectile
  :init (setq ibuffer-show-empty-filter-groups nil)
  :custom (ibuffer-projectile-filter-groups-extra
           '(("Dired" (mode . dired-mode))
             ("Org" (mode . org-mode))
             ("Magit" (name . "^magit"))
             ("Agenda" (or (name . "^\\*Calendar\\*$")
                           (name . "^\\*Org Agenda\\*")))
             ("Emacs"  (or (name . "^\\*scratch\\*$")
                           (name . "^\\*Quail Completion\\*$")
                           (name . "^\\*envrc\\*$")
                           (name . "^\\*Native-compile-Log\\*$")
                           (name . "^\\*doom\\*$")
                           (name . "^\\*Messages\\*$"))))))
``` 

```
;; packages.el
;; Note that you must: rm -rf ~/.emacs.d/.local/straight/{repos,build}/ibuffer-projectile && doom sync
(unpin! ibuffer-projectile)
(package! ibuffer-projectile :recipe (:host github :repo "stites/ibuffer-projectile"))
```